### PR TITLE
fix(core): implement MCP-compliant tools/list response with JSON Schema

### DIFF
--- a/.api-surface-lock.json
+++ b/.api-surface-lock.json
@@ -1,7 +1,7 @@
 {
   "analysis": {
     "packageName": "@hexmcp/core",
-    "packageVersion": "0.8.0",
+    "packageVersion": "0.9.0",
     "types": {
       "kind": "included"
     },
@@ -34,7 +34,7 @@
                 "File '/node_modules/@hexmcp/core/dist/index.d.ts' exists - use it as a name resolution result.",
                 "'package.json' has a 'peerDependencies' field.",
                 "Failed to find peerDependency 'typescript'.",
-                "======== Module name '@hexmcp/core' was successfully resolved to '/node_modules/@hexmcp/core/dist/index.d.ts' with Package ID '@hexmcp/core/dist/index.d.ts@0.8.0'. ========"
+                "======== Module name '@hexmcp/core' was successfully resolved to '/node_modules/@hexmcp/core/dist/index.d.ts' with Package ID '@hexmcp/core/dist/index.d.ts@0.9.0'. ========"
               ]
             },
             "implementationResolution": {
@@ -86,7 +86,7 @@
                 "File '/node_modules/@hexmcp/core/dist/index.tsx' does not exist.",
                 "Failed to resolve under condition 'import'.",
                 "Exiting conditional exports.",
-                "======== Module name '@hexmcp/core' was successfully resolved to '/node_modules/@hexmcp/core/dist/index.js' with Package ID '@hexmcp/core/dist/index.js@0.8.0'. ========"
+                "======== Module name '@hexmcp/core' was successfully resolved to '/node_modules/@hexmcp/core/dist/index.js' with Package ID '@hexmcp/core/dist/index.js@0.9.0'. ========"
               ]
             },
             "files": [
@@ -143,7 +143,7 @@
                 "Failed to find peerDependency 'typescript'.",
                 "Resolved under condition 'types'.",
                 "Exiting conditional exports.",
-                "======== Module name '@hexmcp/core' was successfully resolved to '/node_modules/@hexmcp/core/dist/index.d.ts' with Package ID '@hexmcp/core/dist/index.d.ts@0.8.0'. ========"
+                "======== Module name '@hexmcp/core' was successfully resolved to '/node_modules/@hexmcp/core/dist/index.d.ts' with Package ID '@hexmcp/core/dist/index.d.ts@0.9.0'. ========"
               ]
             },
             "files": [
@@ -198,7 +198,7 @@
                 "File '/node_modules/@hexmcp/core/dist/index.d.ts' exists - use it as a name resolution result.",
                 "Resolved under condition 'types'.",
                 "Exiting conditional exports.",
-                "======== Module name '@hexmcp/core' was successfully resolved to '/node_modules/@hexmcp/core/dist/index.d.ts' with Package ID '@hexmcp/core/dist/index.d.ts@0.8.0'. ========"
+                "======== Module name '@hexmcp/core' was successfully resolved to '/node_modules/@hexmcp/core/dist/index.d.ts' with Package ID '@hexmcp/core/dist/index.d.ts@0.9.0'. ========"
               ]
             },
             "implementationResolution": {
@@ -251,7 +251,7 @@
                 "File '/node_modules/@hexmcp/core/dist/index.js.ts' does not exist.",
                 "File '/node_modules/@hexmcp/core/dist/index.js.tsx' does not exist.",
                 "Directory '/node_modules/@hexmcp/core/dist/index.js' does not exist, skipping all lookups in it.",
-                "======== Module name '@hexmcp/core' was successfully resolved to '/node_modules/@hexmcp/core/dist/index.js' with Package ID '@hexmcp/core/dist/index.js@0.8.0'. ========"
+                "======== Module name '@hexmcp/core' was successfully resolved to '/node_modules/@hexmcp/core/dist/index.js' with Package ID '@hexmcp/core/dist/index.js@0.9.0'. ========"
               ]
             },
             "files": [
@@ -308,7 +308,7 @@
                 "Failed to find peerDependency 'typescript'.",
                 "Resolved under condition 'types'.",
                 "Exiting conditional exports.",
-                "======== Module name '@hexmcp/core' was successfully resolved to '/node_modules/@hexmcp/core/dist/index.d.ts' with Package ID '@hexmcp/core/dist/index.d.ts@0.8.0'. ========"
+                "======== Module name '@hexmcp/core' was successfully resolved to '/node_modules/@hexmcp/core/dist/index.d.ts' with Package ID '@hexmcp/core/dist/index.d.ts@0.9.0'. ========"
               ]
             },
             "implementationResolution": {
@@ -365,7 +365,7 @@
                 "Directory '/node_modules/@hexmcp/core/dist/index.js' does not exist, skipping all lookups in it.",
                 "File '/node_modules/@hexmcp/core/index.ts' does not exist.",
                 "File '/node_modules/@hexmcp/core/index.tsx' does not exist.",
-                "======== Module name '@hexmcp/core' was successfully resolved to '/node_modules/@hexmcp/core/dist/index.js' with Package ID '@hexmcp/core/dist/index.js@0.8.0'. ========"
+                "======== Module name '@hexmcp/core' was successfully resolved to '/node_modules/@hexmcp/core/dist/index.js' with Package ID '@hexmcp/core/dist/index.js@0.9.0'. ========"
               ]
             },
             "files": [
@@ -447,7 +447,7 @@
                 "Directory '/node_modules/@types' does not exist, skipping all lookups in it.",
                 "Scoped package detected, looking in 'hexmcp__core/package.json'",
                 "File name '/node_modules/@types/hexmcp__core/package.json' has a '.json' extension - stripping it.",
-                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.8.0'. ========"
+                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.9.0'. ========"
               ]
             },
             "implementationResolution": {
@@ -479,7 +479,7 @@
                 "Using 'exports' subpath './package.json' with target './package.json'.",
                 "File name '/node_modules/@hexmcp/core/package.json' has a '.json' extension - stripping it.",
                 "Export specifier './package.json' does not exist in package.json scope at path '/node_modules/@hexmcp/core'.",
-                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.8.0'. ========"
+                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.9.0'. ========"
               ]
             },
             "files": [
@@ -515,7 +515,7 @@
                 "Using 'exports' subpath './package.json' with target './package.json'.",
                 "File name '/node_modules/@hexmcp/core/package.json' has a '.json' extension - stripping it.",
                 "File '/node_modules/@hexmcp/core/package.json' exists - use it as a name resolution result.",
-                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.8.0'. ========"
+                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.9.0'. ========"
               ]
             },
             "implementationResolution": {
@@ -538,7 +538,7 @@
                 "Using 'exports' subpath './package.json' with target './package.json'.",
                 "File name '/node_modules/@hexmcp/core/package.json' has a '.json' extension - stripping it.",
                 "File '/node_modules/@hexmcp/core/package.json' exists - use it as a name resolution result.",
-                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.8.0'. ========"
+                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.9.0'. ========"
               ]
             },
             "files": [
@@ -589,7 +589,7 @@
                 "Directory '/node_modules/@types' does not exist, skipping all lookups in it.",
                 "Scoped package detected, looking in 'hexmcp__core/package.json'",
                 "File name '/node_modules/@types/hexmcp__core/package.json' has a '.json' extension - stripping it.",
-                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.8.0'. ========"
+                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.9.0'. ========"
               ]
             },
             "implementationResolution": {
@@ -622,7 +622,7 @@
                 "File name '/node_modules/@hexmcp/core/package.json/dist/index.js' has a '.js' extension - stripping it.",
                 "Loading module as file / folder, candidate module location '/node_modules/@hexmcp/core/package.json/dist/index.js', target file types: TypeScript.",
                 "File name '/node_modules/@hexmcp/core/package.json/dist/index.js' has a '.js' extension - stripping it.",
-                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.8.0'. ========"
+                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.9.0'. ========"
               ]
             },
             "files": [
@@ -676,7 +676,7 @@
                 "Directory '/node_modules/@types' does not exist, skipping all lookups in it.",
                 "Scoped package detected, looking in 'hexmcp__core/package.json'",
                 "File name '/node_modules/@types/hexmcp__core/package.json' has a '.json' extension - stripping it.",
-                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.8.0'. ========"
+                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.9.0'. ========"
               ]
             },
             "implementationResolution": {
@@ -711,7 +711,7 @@
                 "File name '/node_modules/@hexmcp/core/package.json/dist/index.js' has a '.js' extension - stripping it.",
                 "Loading module as file / folder, candidate module location '/node_modules/@hexmcp/core/package.json/dist/index.js', target file types: TypeScript.",
                 "File name '/node_modules/@hexmcp/core/package.json/dist/index.js' has a '.js' extension - stripping it.",
-                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.8.0'. ========"
+                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.9.0'. ========"
               ]
             },
             "files": [

--- a/.changeset/mcp-protocol-compliance.md
+++ b/.changeset/mcp-protocol-compliance.md
@@ -1,0 +1,37 @@
+---
+"@hexmcp/core": minor
+---
+
+Implement MCP-compliant tools/list response with JSON Schema
+
+This release fixes a critical MCP protocol implementation gap where the framework was returning internal metadata format instead of the MCP-compliant format that clients expect.
+
+**Key Changes:**
+
+- **MCP Protocol Compliance**: The `tools/list` handler now returns proper MCP-compliant `Tool` objects with `inputSchema` as JSON Schema objects
+- **JSON Schema Conversion**: Added utilities to convert `ToolParameter[]` and Zod schemas to JSON Schema format
+- **New API Methods**: Added `ToolRegistry.listMcpTools()` method that returns MCP-compliant tool descriptions
+- **Backward Compatibility**: Existing `ToolRegistry.list()` method continues to work for internal use
+- **Type Safety**: Full TypeScript support with proper MCP protocol types from `@modelcontextprotocol/sdk`
+
+**Technical Details:**
+
+- Added `convertParametersToJsonSchema()` for converting tool parameters to JSON Schema
+- Added `convertZodToJsonSchema()` using the official `zod-to-json-schema` package
+- Added `convertToMcpTool()` to transform internal `ToolDefinition` to MCP `Tool` format
+- Updated `tools/list` handler in server builder to use new MCP-compliant format
+- Added comprehensive test coverage for all conversion scenarios
+
+**Migration Guide:**
+
+For most users, this change is transparent as the MCP protocol layer automatically uses the new compliant format. However, if you were directly using the `ToolRegistry.list()` method and expecting MCP-compliant output, you should now use `ToolRegistry.listMcpTools()` instead.
+
+```typescript
+// Before (returned internal metadata)
+const tools = registry.list();
+
+// After (returns MCP-compliant format)
+const tools = registry.listMcpTools();
+```
+
+This fix resolves issues where MCP clients (like Augment) were rejecting servers due to missing or invalid `inputSchema` fields in tool descriptions.

--- a/examples/note-server/README.md
+++ b/examples/note-server/README.md
@@ -6,13 +6,14 @@ A comprehensive example implementation of an MCP (Model Context Protocol) server
 
 This example showcases:
 
-- **Tool Handlers**: Create notes with validation
-- **Resource Handlers**: Access notes via URI patterns with list/get operations  
+- **Tool Handlers**: Create notes with validation and MCP-compliant JSON Schema
+- **Resource Handlers**: Access notes via URI patterns with list/get operations
 - **Prompt Handlers**: Generate note summaries with configurable length
 - **Middleware Integration**: Transport-aware logging and error handling with stderr-only output for stdio compatibility
 - **Transport Layer**: stdio transport for JSON-RPC communication with automatic logging detection
 - **Testing Infrastructure**: Comprehensive fixture-based testing
 - **Type Safety**: Full TypeScript implementation with Zod validation
+- **MCP Protocol Compliance**: Full compliance with MCP protocol specifications including proper `tools/list` responses
 
 ## 🏗️ Architecture
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -10,6 +10,7 @@ Core functionality for MCP Server Framework with lifecycle state machine, handsh
 - 🔌 **Transport Integration**: Seamless integration with transport adapters
 - 📝 **TypeScript First**: Full type safety with comprehensive interfaces
 - ✅ **Well Tested**: 80%+ test coverage with comprehensive edge case testing
+- 🛠️ **MCP Protocol Compliance**: Full compliance with MCP protocol including proper `tools/list` responses with JSON Schema
 
 ## Installation
 

--- a/packages/core/__tests__/registries/mcp-compliance.test.ts
+++ b/packages/core/__tests__/registries/mcp-compliance.test.ts
@@ -1,0 +1,249 @@
+import { z } from 'zod';
+import { ToolRegistry } from '../../src/registries/tools';
+import type { ToolDefinition } from '../../src/registries/types';
+import { convertParametersToJsonSchema, convertToMcpTool, convertZodToJsonSchema } from '../../src/registries/types';
+
+describe('MCP Protocol Compliance', () => {
+  let registry: ToolRegistry;
+
+  beforeEach(() => {
+    registry = new ToolRegistry();
+  });
+
+  describe('JSON Schema Conversion', () => {
+    it('should convert ToolParameter array to JSON Schema', () => {
+      const parameters = [
+        {
+          name: 'title',
+          type: 'string' as const,
+          description: 'The title of the note',
+          required: true,
+        },
+        {
+          name: 'content',
+          type: 'string' as const,
+          description: 'The content of the note',
+          required: true,
+        },
+        {
+          name: 'tags',
+          type: 'array' as const,
+          description: 'Optional tags',
+          required: false,
+        },
+      ];
+
+      const schema = convertParametersToJsonSchema(parameters);
+
+      expect(schema).toEqual({
+        type: 'object',
+        properties: {
+          title: {
+            type: 'string',
+            description: 'The title of the note',
+          },
+          content: {
+            type: 'string',
+            description: 'The content of the note',
+          },
+          tags: {
+            type: 'array',
+            description: 'Optional tags',
+          },
+        },
+        required: ['title', 'content'],
+      });
+    });
+
+    it('should convert Zod schema to JSON Schema', () => {
+      const zodSchema = z.object({
+        name: z.string(),
+        age: z.number(),
+        active: z.boolean().optional(),
+      });
+
+      const schema = convertZodToJsonSchema(zodSchema);
+
+      expect(schema.type).toBe('object');
+      expect(schema.properties).toBeDefined();
+      expect(schema.properties?.name?.type).toBe('string');
+      expect(schema.properties?.age?.type).toBe('number');
+      expect(schema.properties?.active?.type).toBe('boolean');
+      expect(schema.required).toContain('name');
+      expect(schema.required).toContain('age');
+      expect(schema.required).not.toContain('active');
+    });
+
+    it('should handle empty parameters gracefully', () => {
+      const schema = convertParametersToJsonSchema([]);
+      expect(schema).toEqual({
+        type: 'object',
+        properties: {},
+      });
+    });
+  });
+
+  describe('Tool Definition to MCP Tool Conversion', () => {
+    it('should convert tool with parameters to MCP format', () => {
+      const definition: ToolDefinition = {
+        name: 'addNote',
+        description: 'Create a new note',
+        parameters: [
+          {
+            name: 'title',
+            type: 'string',
+            description: 'Note title',
+            required: true,
+          },
+          {
+            name: 'content',
+            type: 'string',
+            description: 'Note content',
+            required: true,
+          },
+        ],
+        handler: async () => ({ content: 'success' }),
+      };
+
+      const mcpTool = convertToMcpTool(definition);
+
+      expect(mcpTool).toEqual({
+        name: 'addNote',
+        description: 'Create a new note',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            title: {
+              type: 'string',
+              description: 'Note title',
+            },
+            content: {
+              type: 'string',
+              description: 'Note content',
+            },
+          },
+          required: ['title', 'content'],
+        },
+      });
+    });
+
+    it('should convert tool with Zod schema to MCP format', () => {
+      const zodSchema = z.object({
+        message: z.string(),
+      });
+
+      const definition: ToolDefinition = {
+        name: 'echo',
+        description: 'Echo a message',
+        inputSchema: zodSchema,
+        handler: async () => ({ content: 'success' }),
+      };
+
+      const mcpTool = convertToMcpTool(definition);
+
+      expect(mcpTool.name).toBe('echo');
+      expect(mcpTool.description).toBe('Echo a message');
+      expect(mcpTool.inputSchema.type).toBe('object');
+      expect(mcpTool.inputSchema.properties).toBeDefined();
+    });
+
+    it('should handle tool without parameters', () => {
+      const definition: ToolDefinition = {
+        name: 'ping',
+        description: 'Simple ping tool',
+        handler: async () => ({ content: 'pong' }),
+      };
+
+      const mcpTool = convertToMcpTool(definition);
+
+      expect(mcpTool).toEqual({
+        name: 'ping',
+        description: 'Simple ping tool',
+        inputSchema: {
+          type: 'object',
+        },
+      });
+    });
+  });
+
+  describe('ToolRegistry MCP Compliance', () => {
+    it('should return MCP-compliant tools list', () => {
+      const definition: ToolDefinition = {
+        name: 'testTool',
+        description: 'A test tool',
+        parameters: [
+          {
+            name: 'input',
+            type: 'string',
+            required: true,
+          },
+        ],
+        handler: async () => ({ content: 'test' }),
+      };
+
+      registry.register(definition);
+      const mcpTools = registry.listMcpTools();
+
+      expect(mcpTools).toHaveLength(1);
+      expect(mcpTools[0]).toEqual({
+        name: 'testTool',
+        description: 'A test tool',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            input: {
+              type: 'string',
+            },
+          },
+          required: ['input'],
+        },
+      });
+    });
+
+    it('should filter tools by tags in MCP format', () => {
+      const tool1: ToolDefinition = {
+        name: 'tool1',
+        tags: ['notes'],
+        handler: async () => ({ content: 'test' }),
+      };
+
+      const tool2: ToolDefinition = {
+        name: 'tool2',
+        tags: ['files'],
+        handler: async () => ({ content: 'test' }),
+      };
+
+      registry.register(tool1);
+      registry.register(tool2);
+
+      const notesTools = registry.listMcpTools({ tags: ['notes'] });
+      expect(notesTools).toHaveLength(1);
+      expect(notesTools[0]?.name).toBe('tool1');
+    });
+
+    it('should maintain backward compatibility with legacy list method', () => {
+      const definition: ToolDefinition = {
+        name: 'legacyTool',
+        description: 'A legacy tool',
+        tags: ['legacy'],
+        version: '1.0.0',
+        dangerous: true,
+        handler: async () => ({ content: 'test' }),
+      };
+
+      registry.register(definition);
+      const legacyList = registry.list();
+
+      expect(legacyList).toHaveLength(1);
+      expect(legacyList[0]).toMatchObject({
+        name: 'legacyTool',
+        description: 'A legacy tool',
+        tags: ['legacy'],
+        version: '1.0.0',
+        dangerous: true,
+        hasSchema: false,
+        hasHooks: false,
+      });
+    });
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,8 @@
     "@hexmcp/transport": "workspace:*",
     "@hexmcp/transport-stdio": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.13.2",
-    "zod": "^3.25.67"
+    "zod": "^3.25.67",
+    "zod-to-json-schema": "^3.24.6"
   },
   "peerDependencies": {
     "typescript": "^5.0.0"

--- a/packages/core/src/builder/server.ts
+++ b/packages/core/src/builder/server.ts
@@ -188,7 +188,7 @@ class McpServerBuilderImpl implements McpServerBuilder {
                 );
                 break;
               }
-              const tools = toolRegistry.list();
+              const tools = toolRegistry.listMcpTools();
               requestContext.response = encodeJsonRpcSuccess(jsonRpcRequest.id, { tools });
               break;
             }

--- a/packages/core/src/registries/tools.ts
+++ b/packages/core/src/registries/tools.ts
@@ -1,8 +1,9 @@
-import type { ServerCapabilities } from '@modelcontextprotocol/sdk/types.js';
+import type { ServerCapabilities, Tool } from '@modelcontextprotocol/sdk/types.js';
 
 import type { Registry, RegistryMetadata, RegistryStats } from './base';
 import { REGISTRY_KINDS } from './base';
 import type { HandlerContext, ToolDefinition } from './types';
+import { convertToMcpTool } from './types';
 
 /**
  * Registry for managing tool handlers in the MCP Server Framework.
@@ -295,7 +296,25 @@ export class ToolRegistry implements Registry {
   }
 
   /**
-   * List all registered tools with optional filtering
+   * List all registered tools in MCP-compliant format
+   */
+  listMcpTools(options?: { tags?: string[]; dangerous?: boolean }): Tool[] {
+    let tools = Array.from(this._tools.values());
+
+    if (options?.tags && options.tags.length > 0) {
+      const filterTags = options.tags;
+      tools = tools.filter((t) => t.tags && filterTags.some((tag) => t.tags?.includes(tag)));
+    }
+
+    if (options?.dangerous !== undefined) {
+      tools = tools.filter((t) => Boolean(t.dangerous) === options.dangerous);
+    }
+
+    return tools.map((tool) => convertToMcpTool(tool));
+  }
+
+  /**
+   * List all registered tools with optional filtering (legacy format for internal use)
    */
   list(options?: { tags?: string[]; dangerous?: boolean; withScope?: boolean; withSchema?: boolean }): Array<{
     name: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,9 @@ importers:
       zod:
         specifier: ^3.25.67
         version: 3.25.67
+      zod-to-json-schema:
+        specifier: ^3.24.6
+        version: 3.24.6(zod@3.25.67)
     devDependencies:
       '@types/jest':
         specifier: ^30.0.0

--- a/scripts/quality-gate.ts
+++ b/scripts/quality-gate.ts
@@ -79,14 +79,14 @@ const QUALITY_STEPS: QualityStep[] = [
     name: 'check:types',
     description: 'API surface lock validation',
     command: 'pnpm check:types',
-    required: false, // Optional until declaration file issues are resolved
+    required: true,
     timeout: 60000,
   },
   {
     name: 'docs:generate',
     description: 'Documentation generation',
     command: 'pnpm docs:generate',
-    required: false, // Optional until declaration file issues are resolved
+    required: true,
     timeout: 120000,
   },
 ];


### PR DESCRIPTION
- Add JSON Schema conversion utilities for ToolParameter[] and Zod schemas
- Create new listMcpTools() method returning MCP-compliant Tool format
- Update tools/list handler to use proper MCP protocol format
- Add comprehensive test coverage for MCP compliance
- Maintain backward compatibility with existing list() method
- Add zod-to-json-schema dependency for proper schema conversion.