### PR TITLE
feat: integrate API surface lock updates into release workflow

### DIFF
--- a/.api-surface-lock.json
+++ b/.api-surface-lock.json
@@ -1,7 +1,7 @@
 {
   "analysis": {
     "packageName": "@hexmcp/core",
-    "packageVersion": "0.9.0",
+    "packageVersion": "0.10.0",
     "types": {
       "kind": "included"
     },
@@ -34,7 +34,7 @@
                 "File '/node_modules/@hexmcp/core/dist/index.d.ts' exists - use it as a name resolution result.",
                 "'package.json' has a 'peerDependencies' field.",
                 "Failed to find peerDependency 'typescript'.",
-                "======== Module name '@hexmcp/core' was successfully resolved to '/node_modules/@hexmcp/core/dist/index.d.ts' with Package ID '@hexmcp/core/dist/index.d.ts@0.9.0'. ========"
+                "======== Module name '@hexmcp/core' was successfully resolved to '/node_modules/@hexmcp/core/dist/index.d.ts' with Package ID '@hexmcp/core/dist/index.d.ts@0.10.0'. ========"
               ]
             },
             "implementationResolution": {
@@ -86,7 +86,7 @@
                 "File '/node_modules/@hexmcp/core/dist/index.tsx' does not exist.",
                 "Failed to resolve under condition 'import'.",
                 "Exiting conditional exports.",
-                "======== Module name '@hexmcp/core' was successfully resolved to '/node_modules/@hexmcp/core/dist/index.js' with Package ID '@hexmcp/core/dist/index.js@0.9.0'. ========"
+                "======== Module name '@hexmcp/core' was successfully resolved to '/node_modules/@hexmcp/core/dist/index.js' with Package ID '@hexmcp/core/dist/index.js@0.10.0'. ========"
               ]
             },
             "files": [
@@ -143,7 +143,7 @@
                 "Failed to find peerDependency 'typescript'.",
                 "Resolved under condition 'types'.",
                 "Exiting conditional exports.",
-                "======== Module name '@hexmcp/core' was successfully resolved to '/node_modules/@hexmcp/core/dist/index.d.ts' with Package ID '@hexmcp/core/dist/index.d.ts@0.9.0'. ========"
+                "======== Module name '@hexmcp/core' was successfully resolved to '/node_modules/@hexmcp/core/dist/index.d.ts' with Package ID '@hexmcp/core/dist/index.d.ts@0.10.0'. ========"
               ]
             },
             "files": [
@@ -198,7 +198,7 @@
                 "File '/node_modules/@hexmcp/core/dist/index.d.ts' exists - use it as a name resolution result.",
                 "Resolved under condition 'types'.",
                 "Exiting conditional exports.",
-                "======== Module name '@hexmcp/core' was successfully resolved to '/node_modules/@hexmcp/core/dist/index.d.ts' with Package ID '@hexmcp/core/dist/index.d.ts@0.9.0'. ========"
+                "======== Module name '@hexmcp/core' was successfully resolved to '/node_modules/@hexmcp/core/dist/index.d.ts' with Package ID '@hexmcp/core/dist/index.d.ts@0.10.0'. ========"
               ]
             },
             "implementationResolution": {
@@ -251,7 +251,7 @@
                 "File '/node_modules/@hexmcp/core/dist/index.js.ts' does not exist.",
                 "File '/node_modules/@hexmcp/core/dist/index.js.tsx' does not exist.",
                 "Directory '/node_modules/@hexmcp/core/dist/index.js' does not exist, skipping all lookups in it.",
-                "======== Module name '@hexmcp/core' was successfully resolved to '/node_modules/@hexmcp/core/dist/index.js' with Package ID '@hexmcp/core/dist/index.js@0.9.0'. ========"
+                "======== Module name '@hexmcp/core' was successfully resolved to '/node_modules/@hexmcp/core/dist/index.js' with Package ID '@hexmcp/core/dist/index.js@0.10.0'. ========"
               ]
             },
             "files": [
@@ -308,7 +308,7 @@
                 "Failed to find peerDependency 'typescript'.",
                 "Resolved under condition 'types'.",
                 "Exiting conditional exports.",
-                "======== Module name '@hexmcp/core' was successfully resolved to '/node_modules/@hexmcp/core/dist/index.d.ts' with Package ID '@hexmcp/core/dist/index.d.ts@0.9.0'. ========"
+                "======== Module name '@hexmcp/core' was successfully resolved to '/node_modules/@hexmcp/core/dist/index.d.ts' with Package ID '@hexmcp/core/dist/index.d.ts@0.10.0'. ========"
               ]
             },
             "implementationResolution": {
@@ -365,7 +365,7 @@
                 "Directory '/node_modules/@hexmcp/core/dist/index.js' does not exist, skipping all lookups in it.",
                 "File '/node_modules/@hexmcp/core/index.ts' does not exist.",
                 "File '/node_modules/@hexmcp/core/index.tsx' does not exist.",
-                "======== Module name '@hexmcp/core' was successfully resolved to '/node_modules/@hexmcp/core/dist/index.js' with Package ID '@hexmcp/core/dist/index.js@0.9.0'. ========"
+                "======== Module name '@hexmcp/core' was successfully resolved to '/node_modules/@hexmcp/core/dist/index.js' with Package ID '@hexmcp/core/dist/index.js@0.10.0'. ========"
               ]
             },
             "files": [
@@ -447,7 +447,7 @@
                 "Directory '/node_modules/@types' does not exist, skipping all lookups in it.",
                 "Scoped package detected, looking in 'hexmcp__core/package.json'",
                 "File name '/node_modules/@types/hexmcp__core/package.json' has a '.json' extension - stripping it.",
-                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.9.0'. ========"
+                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.10.0'. ========"
               ]
             },
             "implementationResolution": {
@@ -479,7 +479,7 @@
                 "Using 'exports' subpath './package.json' with target './package.json'.",
                 "File name '/node_modules/@hexmcp/core/package.json' has a '.json' extension - stripping it.",
                 "Export specifier './package.json' does not exist in package.json scope at path '/node_modules/@hexmcp/core'.",
-                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.9.0'. ========"
+                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.10.0'. ========"
               ]
             },
             "files": [
@@ -515,7 +515,7 @@
                 "Using 'exports' subpath './package.json' with target './package.json'.",
                 "File name '/node_modules/@hexmcp/core/package.json' has a '.json' extension - stripping it.",
                 "File '/node_modules/@hexmcp/core/package.json' exists - use it as a name resolution result.",
-                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.9.0'. ========"
+                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.10.0'. ========"
               ]
             },
             "implementationResolution": {
@@ -538,7 +538,7 @@
                 "Using 'exports' subpath './package.json' with target './package.json'.",
                 "File name '/node_modules/@hexmcp/core/package.json' has a '.json' extension - stripping it.",
                 "File '/node_modules/@hexmcp/core/package.json' exists - use it as a name resolution result.",
-                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.9.0'. ========"
+                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.10.0'. ========"
               ]
             },
             "files": [
@@ -589,7 +589,7 @@
                 "Directory '/node_modules/@types' does not exist, skipping all lookups in it.",
                 "Scoped package detected, looking in 'hexmcp__core/package.json'",
                 "File name '/node_modules/@types/hexmcp__core/package.json' has a '.json' extension - stripping it.",
-                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.9.0'. ========"
+                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.10.0'. ========"
               ]
             },
             "implementationResolution": {
@@ -622,7 +622,7 @@
                 "File name '/node_modules/@hexmcp/core/package.json/dist/index.js' has a '.js' extension - stripping it.",
                 "Loading module as file / folder, candidate module location '/node_modules/@hexmcp/core/package.json/dist/index.js', target file types: TypeScript.",
                 "File name '/node_modules/@hexmcp/core/package.json/dist/index.js' has a '.js' extension - stripping it.",
-                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.9.0'. ========"
+                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.10.0'. ========"
               ]
             },
             "files": [
@@ -676,7 +676,7 @@
                 "Directory '/node_modules/@types' does not exist, skipping all lookups in it.",
                 "Scoped package detected, looking in 'hexmcp__core/package.json'",
                 "File name '/node_modules/@types/hexmcp__core/package.json' has a '.json' extension - stripping it.",
-                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.9.0'. ========"
+                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.10.0'. ========"
               ]
             },
             "implementationResolution": {
@@ -711,7 +711,7 @@
                 "File name '/node_modules/@hexmcp/core/package.json/dist/index.js' has a '.js' extension - stripping it.",
                 "Loading module as file / folder, candidate module location '/node_modules/@hexmcp/core/package.json/dist/index.js', target file types: TypeScript.",
                 "File name '/node_modules/@hexmcp/core/package.json/dist/index.js' has a '.js' extension - stripping it.",
-                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.9.0'. ========"
+                "======== Module name '@hexmcp/core/package.json' was successfully resolved to '/node_modules/@hexmcp/core/package.json' with Package ID '@hexmcp/core/package.json@0.10.0'. ========"
               ]
             },
             "files": [

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,42 @@ jobs:
           # NPM_TOKEN not needed since we're not publishing yet
           # Will be added when ready for public releases after MVP completion
 
+      # Update API surface after version changes to ensure consistency
+      - name: Update API Surface After Version Changes
+        if: steps.changesets.outputs.hasChangesets == 'true'
+        run: |
+          echo "🔄 Updating API surface after version changes..."
+
+          # Rebuild packages with new versions
+          pnpm run build
+
+          # Update API surface lock and reports
+          pnpm run update:surface
+          pnpm run update:api-reports
+
+          # Check if there are changes to commit
+          if ! git diff --quiet .api-surface-lock.json || ([ -d "temp/api-reports" ] && ! git diff --quiet temp/api-reports/); then
+            echo "📝 Committing API surface updates..."
+
+            git config --local user.email "action@github.com"
+            git config --local user.name "GitHub Action"
+
+            # Add changed files
+            git add .api-surface-lock.json
+            if [ -d "temp/api-reports" ]; then
+              git add temp/api-reports/
+            fi
+
+            git commit -m "chore: update API surface lock after version bump" \
+                       -m "Auto-generated API surface updates following version changes." \
+                       -m "- Updated .api-surface-lock.json with new package versions" \
+                       -m "- Regenerated API reports in temp/api-reports/" \
+                       -m "[skip ci]"
+            git push
+          else
+            echo "✅ No API surface changes detected"
+          fi
+
       # Log information about the changesets action results
       - name: Log Changesets Results
         run: |

--- a/.github/workflows/update-api-surface.yml
+++ b/.github/workflows/update-api-surface.yml
@@ -4,9 +4,10 @@ on:
   push:
     branches: [main]
     paths:
-      - 'packages/core/src/**'
-      - 'packages/core/package.json'
-      - 'packages/core/tsconfig.json'
+      # Monitor all packages dynamically for flexibility
+      - 'packages/*/src/**'
+      - 'packages/*/tsconfig.json'
+      # Remove package.json files to avoid conflicts with release workflow
 
 permissions:
   contents: write
@@ -20,29 +21,89 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 2  # Need previous commit for comparison
+
+      - name: Check if version-only change
+        id: version_check
+        run: |
+          echo "🔍 Checking if this is a version-only change..."
+
+          # Get list of changed files
+          CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD)
+          echo "Changed files: $CHANGED_FILES"
+
+          # Check if any package.json files changed
+          PACKAGE_JSON_CHANGED=false
+          if echo "$CHANGED_FILES" | grep -q "packages/.*/package.json"; then
+            PACKAGE_JSON_CHANGED=true
+          fi
+
+          # Check if only version fields changed in package.json files
+          VERSION_ONLY=false
+          if [ "$PACKAGE_JSON_CHANGED" = true ]; then
+            echo "📦 Package.json files changed, checking if version-only..."
+            # Check each changed package.json to see if only version changed
+            for file in $(echo "$CHANGED_FILES" | grep "packages/.*/package.json" || true); do
+              if [ -f "$file" ]; then
+                echo "Checking $file for version-only changes..."
+                # Check if version field changed
+                if git diff HEAD~1 HEAD "$file" | grep -E '^\+.*"version":|^\-.*"version":' > /dev/null; then
+                  # Count non-version related changes (excluding CHANGELOG references)
+                  NON_VERSION_CHANGES=$(git diff HEAD~1 HEAD "$file" | grep -E '^\+|^\-' | grep -v -E '"version":|"CHANGELOG.md"' | wc -l)
+                  echo "Non-version changes in $file: $NON_VERSION_CHANGES"
+                  if [ "$NON_VERSION_CHANGES" -eq 0 ]; then
+                    VERSION_ONLY=true
+                    echo "✅ $file appears to be version-only change"
+                  else
+                    VERSION_ONLY=false
+                    echo "❌ $file has non-version changes"
+                    break
+                  fi
+                fi
+              fi
+            done
+          fi
+
+          echo "version_only=$VERSION_ONLY" >> $GITHUB_OUTPUT
+          echo "📊 Final result - Version-only change: $VERSION_ONLY"
+
+      - name: Skip if version-only change
+        if: steps.version_check.outputs.version_only == 'true'
+        run: |
+          echo "⏭️ Skipping API surface update - this appears to be a version-only change"
+          echo "API surface updates for version changes are handled by the release workflow"
+          echo "This prevents duplicate commits and race conditions"
+          exit 0
 
       - name: Setup PNPM
+        if: steps.version_check.outputs.version_only != 'true'
         uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
+        if: steps.version_check.outputs.version_only != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'pnpm'
 
       - name: Install dependencies
+        if: steps.version_check.outputs.version_only != 'true'
         run: pnpm install
 
       - name: Build packages
+        if: steps.version_check.outputs.version_only != 'true'
         run: pnpm run build
 
       - name: Update API surface lock
+        if: steps.version_check.outputs.version_only != 'true'
         run: pnpm run update:surface
 
       - name: Update API reports
+        if: steps.version_check.outputs.version_only != 'true'
         run: pnpm run update:api-reports
 
       - name: Check for changes
+        if: steps.version_check.outputs.version_only != 'true'
         id: changes
         run: |
           # Check if .api-surface-lock.json has changes
@@ -66,7 +127,7 @@ jobs:
           fi
 
       - name: Commit API surface updates
-        if: steps.changes.outputs.changed == 'true'
+        if: steps.version_check.outputs.version_only != 'true' && steps.changes.outputs.changed == 'true'
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"


### PR DESCRIPTION
- Fix current version mismatch (.api-surface-lock.json 0.9.0 → 0.10.0)
- Add automatic API surface updates to release workflow after version changes
- Implement intelligent conflict detection in update-api-surface workflow
- Use flexible glob patterns (packages/*/src/**) for dynamic package monitoring
- Prevent race conditions between release and surface update workflows
- Ensure atomic version + API surface updates in single workflow

This eliminates the need to manually run 'update-surface lock' when CI creates version packages PRs, as the API surface lock is now automatically updated as part of the version update process.